### PR TITLE
refactor: set password strength in html not css

### DIFF
--- a/app/src/app/components/home/home.component.pug
+++ b/app/src/app/components/home/home.component.pug
@@ -41,7 +41,14 @@
                   label.btn.btn-sm
                     input(type="checkbox", value="false", #passwordToggle, (change)="togglePasswordVisibility(passwordToggle.checked)")
                     i.fa(aria-hidden="true", [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}")
-                span.input-group-text.password-strength
+                div.input-group-text.password-strength(style="justify-content:center")
+                  ng-container([ngSwitch]="passwordStrength")
+                    ng-container(*ngSwitchCase="-1") Strength
+                    ng-container(*ngSwitchCase="2") Medium
+                    ng-container(*ngSwitchCase="3") Good
+                    ng-container(*ngSwitchCase="4") Strong
+                    //- covers case 0 and 1 which a weak
+                    ng-container(*ngSwitchDefault) Weak
             .invalid-feedback.pl-2.mb-2(*ngIf="password.errors?.required && password.dirty") Please specify a password
             input.password-input.form-control.form-control-sm(
               type="password",

--- a/app/src/app/components/home/home.component.scss
+++ b/app/src/app/components/home/home.component.scss
@@ -73,42 +73,22 @@ $drop-zone-bgcolor: rgba($primary, 0.9);
     &.default {
       color: #7b8a8b;
       border-left: 1px solid $gray-400;
-
-      &::after {
-        content: "Strength";
-      }
     }
 
     &.weak {
       background-color: #8b0000;
-
-      &::after {
-        content: "Weak";
-      }
     }
 
     &.medium {
       background-color: #ffa500;
-
-      &::after {
-        content: "Medium";
-      }
     }
 
     &.good {
       background-color: #4169e1;
-
-      &::after {
-        content: "Good";
-      }
     }
 
     &.strong {
       background-color: #006400;
-
-      &::after {
-        content: "Strong";
-      }
     }
   }
 }

--- a/app/src/app/components/home/home.component.ts
+++ b/app/src/app/components/home/home.component.ts
@@ -33,11 +33,11 @@ export class HomeComponent implements OnInit, OnDestroy, AfterViewInit {
   public readonly showPassword         = false; // used only by the view;
 
   constructor(
-    formBuilder: FormBuilder,
     private electronService: ElectronService,
     private pdfService: PdfProtectService,
     private route: ActivatedRoute,
-    private changeDetector: ChangeDetectorRef) {
+    private changeDetector: ChangeDetectorRef,
+    formBuilder: FormBuilder) {
       this.unsubscriber = new Subject<void>();
       this.createForm(pdfService, formBuilder);
   }

--- a/app/src/app/components/home/password-strength-meter/password-strength-meter.directive.ts
+++ b/app/src/app/components/home/password-strength-meter/password-strength-meter.directive.ts
@@ -21,9 +21,10 @@ const DEFAULT_STRENGTH = -1;
 export class PasswordStrengthMeterDirective implements OnInit, OnDestroy {
   private unsubscribe = new Subject<void>();
   private currentCssClass = '';
-
   private source: HTMLInputElement;
   private target: HTMLElement;
+
+  public readonly passwordStrength: number;
 
   constructor(private el: ElementRef, private renderer: Renderer2) {
     this.currentCssClass = CSS_STRENGTH_MAP[DEFAULT_STRENGTH];
@@ -51,21 +52,25 @@ export class PasswordStrengthMeterDirective implements OnInit, OnDestroy {
 
   public updatePasswordStrength(): void {
     const value = this.source.value;
+    let strength = DEFAULT_STRENGTH;
 
-    if (!value || value.length === 0) {
-      this.setStrength(DEFAULT_STRENGTH);
-      return;
+    if (value && value.length > 0) {
+      strength = zxcvbn(value).score;
     }
 
-    const result = zxcvbn(value);
-    this.setStrength(result.score);
+    this.setStrength(strength);
   }
 
   private setStrength(strength: number): void {
-    this.renderer.removeClass(this.target, this.currentCssClass);
+    if (strength === this.passwordStrength) {
+      return;
+    }
 
+    this.renderer.removeClass(this.target, this.currentCssClass);
     const cssClass = CSS_STRENGTH_MAP[strength];
+
     this.renderer.addClass(this.target, cssClass);
     this.currentCssClass = cssClass;
+    (this as { passwordStrength: number }).passwordStrength = strength;
   }
 }

--- a/app/src/app/components/home/password-strength-meter/password-strength-meter.directive.ts
+++ b/app/src/app/components/home/password-strength-meter/password-strength-meter.directive.ts
@@ -19,27 +19,29 @@ const DEFAULT_STRENGTH = -1;
   selector: '[appPasswordStrengthMeter]'
 })
 export class PasswordStrengthMeterDirective implements OnInit, OnDestroy {
-  private unsubscribe = new Subject<void>();
-  private currentCssClass = '';
+  private unsubscribe: Subject<void>;
+  private currentCssClass: string;
   private source: HTMLInputElement;
   private target: HTMLElement;
 
   public readonly passwordStrength: number;
 
   constructor(private el: ElementRef, private renderer: Renderer2) {
+    this.unsubscribe     = new Subject<void>();
     this.currentCssClass = CSS_STRENGTH_MAP[DEFAULT_STRENGTH];
   }
 
   public ngOnInit(): void {
-    const parent = this.el.nativeElement as HTMLElement;
-    this.source = parent.querySelector('.password-input') as HTMLInputElement;
-    this.target = parent.querySelector('.password-strength') as HTMLElement;
+    const parent  = this.el.nativeElement as HTMLElement;
+    this.source   = parent.querySelector('.password-input') as HTMLInputElement;
+    this.target   = parent.querySelector('.password-strength') as HTMLElement;
 
     const input   = fromEvent<void>(this.source, 'input');
     const change  = fromEvent<void>(this.source, 'change');
-    const handler = merge(input, change);
 
-    handler
+    const onInputChange = merge(input, change);
+
+    onInputChange
       .pipe(takeUntil(this.unsubscribe))
       .subscribe(() => this.updatePasswordStrength());
 

--- a/app/src/app/components/password-gen/password-gen.component.ts
+++ b/app/src/app/components/password-gen/password-gen.component.ts
@@ -37,7 +37,7 @@ export class PasswordGenComponent implements OnInit {
 
   public generatePassword(): void {
     const options = this.passwordOptions.value;
-    const pwd = PasswordGenerator.generate(options);
+    const pwd     = PasswordGenerator.generate(options);
     this.password.setValue(pwd);
   }
 }

--- a/app/src/app/components/password-gen/password-gen.component.ts
+++ b/app/src/app/components/password-gen/password-gen.component.ts
@@ -28,7 +28,7 @@ export class PasswordGenComponent implements OnInit {
   public ngOnInit(): void {
     this.passwordOptions.valueChanges
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(passwordOptions => {
+      .subscribe(_ => {
         this.generatePassword();
       });
 

--- a/app/src/app/components/password-gen/password-options/password-options.component.ts
+++ b/app/src/app/components/password-gen/password-options/password-options.component.ts
@@ -21,16 +21,16 @@ const PASSWORD_OPTIONS_VALUE_ACCESSOR = {
   providers: [PASSWORD_OPTIONS_VALUE_ACCESSOR]
 })
 export class PasswordOptionsComponent implements OnInit, OnDestroy, ControlValueAccessor {
-  private innerValue = new PasswordOptions();
+  private innerValue   = new PasswordOptions();
   private unsubscriber = new Subject<void>();
 
   public passwordOptions: FormGroup;
 
-  public get passwordLength(): AbstractControl { return this.passwordOptions.get('passwordLength'); }
-
   constructor(formBuilder: FormBuilder) {
     this.createForm(formBuilder);
   }
+
+  public get passwordLength(): AbstractControl { return this.passwordOptions.get('passwordLength'); }
 
   public ngOnInit(): void {
     this.passwordOptions.valueChanges

--- a/app/src/app/components/password-gen/password-options/password-options.component.ts
+++ b/app/src/app/components/password-gen/password-options/password-options.component.ts
@@ -78,7 +78,14 @@ export class PasswordOptionsComponent implements OnInit, OnDestroy, ControlValue
     const { passwordLength, lowerCase, upperCase, numbers, specialChars } = this.innerValue;
 
     this.passwordOptions = builder.group({
-      passwordLength: [passwordLength, Validators.compose([Validators.required, Validators.min(0), Validators.max(100)])],
+      passwordLength: [
+        passwordLength,
+        Validators.compose([
+          Validators.required,
+          Validators.min(0),
+          Validators.max(100)]
+        )
+      ],
       lowerCase,
       upperCase,
       numbers,


### PR DESCRIPTION
Removed the setting of the password strength name from css to html by adding an ng-switch to a bunch of ng-containers.
Did a little bit of refactoring in general.